### PR TITLE
fix pagination logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.1.2](https://github.com/Cognigy/Cognigy-CLI/compare/v1.1.1...v1.1.2) (2022-06-17)
+
+
+### Bug Fixes
+
+* **clone agent:** cloning agent retrieved the task ([978994a](https://github.com/Cognigy/Cognigy-CLI/commit/978994a9a07f23f544f8c091117a018eb1f67495)), closes [#25972](https://github.com/Cognigy/Cognigy-CLI/issues/25972)
+* **lexicons:** clone agent lexicons ([ad43d61](https://github.com/Cognigy/Cognigy-CLI/commit/ad43d6146fd7316da6287a6d1ee899999c8a6dee)), closes [#25972](https://github.com/Cognigy/Cognigy-CLI/issues/25972)
+
 ## [1.1.1](https://github.com/Cognigy/Cognigy-CLI/compare/v1.1.0...v1.1.1) (2022-05-18)
 
 

--- a/src/utils/indexAll.ts
+++ b/src/utils/indexAll.ts
@@ -15,6 +15,7 @@ export const indexAll = <Query, Entity>(indexFn: TIndexFn<Query, Entity>) => {
 
 		const firstResponse = await indexFn({
 			...query,
+			limit: MAX_LIMIT,
 			skip: 0
 		});
 


### PR DESCRIPTION
This fixes a bug in the pagination logic.

Before if the agent contained for example 60 flows only 25 (the default value for limit) flows would have been cloned. However, the logic assumes that up to 100 flows are cloned (due to line 27).