### PR TITLE
fix(pagination): make pagination logic get more than 25 resources

### DIFF
--- a/src/utils/indexAll.ts
+++ b/src/utils/indexAll.ts
@@ -1,7 +1,7 @@
 import { AsyncReturnType } from 'type-fest';
 import { IRestPagination, ICursorBasedPaginationReturnValue } from '@cognigy/rest-api-client/build/shared/mongoose/pagination';
 
-const MAX_LIMIT = 100;
+const MAX_LIMIT = 25;
 type TIndexFn<Query extends IRestPagination<Entity>, Entity> = (query: Query) => Promise<ICursorBasedPaginationReturnValue<Entity>>;
 
 export const indexAll = <Query, Entity>(indexFn: TIndexFn<Query, Entity>) => {
@@ -15,6 +15,7 @@ export const indexAll = <Query, Entity>(indexFn: TIndexFn<Query, Entity>) => {
 
 		const firstResponse = await indexFn({
 			...query,
+			limit: 999999,
 			skip: 0
 		});
 


### PR DESCRIPTION
paging wasnt working as only 25 items got loaded in firstResponse (without giving limit parameter)
So the amount of pages cant be counted correctly (25 results in firstResponse of 25 is just one page)
Giving a very high limit of 99999 results in getting the correct amount of results, so that paging can work correctly. Also MAX_LIMIT of 100 will not count the pages correctly if only 25 results are returned: 25 of 100 is just one page.