### PR TITLE
fix(snapshots): Download Snapshot as ArrayBuffer

### DIFF
--- a/src/lib/snapshots.ts
+++ b/src/lib/snapshots.ts
@@ -47,7 +47,7 @@ export const createSnapshot = async (name: string, description: string, timeout:
             });
 
             spinner.setSpinnerTitle(`Downloading Snapshot ... %s`);
-            const snapshotFile = (await axios.get(downloadLink.downloadLink)).data;
+            const snapshotFile = (await axios.get(downloadLink.downloadLink, {responseType: 'arraybuffer'})).data;
 
             fs.writeFileSync(snapshotDir + '/' + snap.name + '.csnap', snapshotFile);
         }


### PR DESCRIPTION
Axios downloads the snapshot and decodes it by default. With setting `responseType: 'arraybuffer'` the response body is not decoded and instead written as buffer to the file. Otherwise the snapshot is corrupt.