### PR TITLE
fix(vulnerability): fixing axios version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@google-cloud/translate": "8.1.0",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@langchain/community": "0.3.29",
-        "axios": "^1.8.3",
+        "axios": "1.8.3",
         "chalk": "4.1.2",
         "cheerio": "1.0.0-rc.12",
         "cli-progress": "3.12.0",
@@ -476,17 +476,6 @@
         "node": ">=22.1.0",
         "npm": ">=10.1.0",
         "vscode": "^1.22.0"
-      }
-    },
-    "node_modules/@cognigy/rest-api-client/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@cognigy/rest-api-client/node_modules/form-data": {
@@ -5943,18 +5932,6 @@
       "integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/ibm-cloud-sdk-core/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "node_modules/ibm-cloud-sdk-core/node_modules/debug": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
   },
   "overrides": {
     "cross-spawn": "7.0.5",
-    "srt-parser-2": "1.1.3"
+    "srt-parser-2": "1.1.3",
+    "axios": "1.8.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
axios is being resolved to 1.7.9 in rest-client.
Rest-client uses 1.8.3 exact version.
It gets published without lock file.
cli when installing somehow picks 1.7.9 for rest-client.
I'm not sure why this is happening. So I'm overriding the version.