### PR TITLE
fix(bug): use stream when downloading snapshot locally

### DIFF
--- a/src/lib/snapshots.ts
+++ b/src/lib/snapshots.ts
@@ -54,11 +54,14 @@ export const createSnapshot = async (
       spinner.setSpinnerTitle(`Downloading Snapshot ... %s`);
       const snapshotFile = (
         await axios.get(downloadLink.downloadLink, {
-          responseType: 'arraybuffer',
+          responseType: 'stream',
         })
       ).data;
 
-      fs.writeFileSync(snapshotDir + '/' + snap.name + '.csnap', snapshotFile);
+      const writer = fs.createWriteStream(
+        snapshotDir + '/' + snap.name + '.csnap'
+      );
+      snapshotFile.pipe(writer);
     }
 
     spinner.stop();


### PR DESCRIPTION
This PR is about fixing the issue where large snapshot couldn't be downloaded via CLI. In order to fix it streams are used. 

How to test it:
1) Update the ["max old space size" memory restriction](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-mib) option in your terminal when running the command. Side note, --max-semi-space-size applies only to the current terminal session and resets when a new terminal is opened.
2) Update the [download link](https://github.com/Cognigy/Cognigy-CLI/compare/bug/98035-large-snapshot-fail-download?expand=1#diff-1c790fd7cb68b5a401e4cf001b178200efd26cd68bbc2881024e766c2a245b9eR56) with the link of a really big file. I used a link from [ipv4.download.thinkbroadband.com](ipv4.download.thinkbroadband.com) but you are free to use any other link: `http://ipv4.download.thinkbroadband.com/5GB.zip`. Side note, if you follow this method it will take some time to download.
