### PR TITLE
feat(cli): correctly version the package cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognigy/cognigy-cli",
-  "version": "1.6.4",
+  "version": "0.0.0-semantic-release",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognigy/cognigy-cli",
-      "version": "1.6.4",
+      "version": "0.0.0-semantic-release",
       "license": "MIT",
       "dependencies": {
         "-": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognigy/cognigy-cli",
-  "version": "1.6.4",
+  "version": "0.0.0-semantic-release",
   "description": "Cognigy Command Line Interface",
   "main": "./build/cognigy.js",
   "scripts": {


### PR DESCRIPTION
In a previous [commit](https://github.com/Cognigy/Cognigy-CLI/commit/501a3216e18c8ed1ba05fc73c8107e3729678ead#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3) the package version was changed from 0.0.0-release-semantic to 1.6.0. I am restoring the version to 0.0.0.semantic-release in this PR.

More than likely this change was done mistakenly by running the release script locally. If we want to have the version of the package based on the latest release we can just add [package.json](https://github.com/Cognigy/Cognigy-CLI/blob/main/release.config.js#L33) in the release script.