### PR TITLE
feat(headers): adding info headers

### DIFF
--- a/src/utils/RestAdapter.ts
+++ b/src/utils/RestAdapter.ts
@@ -18,10 +18,19 @@ interface IOptions {
 export class RestAdapter implements IHttpAdapter {
   private config: IRestAPIClientConfig;
   private options: IOptions;
+  private cliVersion: string;
+  private agentId: string;
 
-  constructor(config?: IRestAPIClientConfig, options?: IOptions) {
-    this.config = config || {};
-    this.options = options || {};
+  constructor(
+    config: IRestAPIClientConfig = {},
+    options: IOptions = {},
+    cliVersion: string = 'unknown',
+    agentId: string = 'unknown'
+  ) {
+    this.config = config;
+    this.options = options;
+    this.cliVersion = cliVersion;
+    this.agentId = agentId;
   }
 
   public setConfig(config: IRestAPIClientConfig): void {
@@ -36,6 +45,15 @@ export class RestAdapter implements IHttpAdapter {
     let axiosResponse: AxiosResponse;
 
     try {
+      // Construct the custom header
+      const cliInfoHeader = `cognigy-cli/${this.cliVersion} project/${this.agentId}`;
+
+      // Ensure headers object exists and add the custom header
+      httpRequest.headers = {
+        ...httpRequest.headers,
+        'X-Cognigy-CLI-Info': cliInfoHeader,
+      };
+
       if (httpRequest.withAuthentication) {
         const authenticationHeaders =
           await client.authenticationHandler?.getAuthenticationHeaders();

--- a/src/utils/RestAdapter.ts
+++ b/src/utils/RestAdapter.ts
@@ -51,8 +51,9 @@ export class RestAdapter implements IHttpAdapter {
       // Ensure headers object exists and add the custom header
       httpRequest.headers = {
         ...httpRequest.headers,
-        'X-Cognigy-CLI-Info': cliInfoHeader,
+        'X-Cognigy-Client-Info': cliInfoHeader,
       };
+      console.log('httpRequest.headers', httpRequest.headers);
 
       if (httpRequest.withAuthentication) {
         const authenticationHeaders =

--- a/src/utils/RestAdapter.ts
+++ b/src/utils/RestAdapter.ts
@@ -53,7 +53,6 @@ export class RestAdapter implements IHttpAdapter {
         ...httpRequest.headers,
         'X-Cognigy-Client-Info': cliInfoHeader,
       };
-      console.log('httpRequest.headers', httpRequest.headers);
 
       if (httpRequest.withAuthentication) {
         const authenticationHeaders =

--- a/src/utils/cognigyClient.ts
+++ b/src/utils/cognigyClient.ts
@@ -1,9 +1,26 @@
 import Cognigy from '@cognigy/rest-api-client';
+import * as fs from 'fs';
+import * as path from 'path';
 import CONFIG from './config';
 import { RestAdapter } from './RestAdapter';
 
+// Read package.json to get the CLI version
+let cliVersion = 'unknown';
+try {
+  const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+  const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+  cliVersion = JSON.parse(packageJsonContent).version;
+} catch (error) {
+  console.error('Error reading package.json for CLI version:', error);
+}
+
 const CognigyClient = new Cognigy({
-  httpAdapter: new RestAdapter({}, { retries: 10 }),
+  httpAdapter: new RestAdapter(
+    {},
+    { retries: 10 },
+    cliVersion,
+    CONFIG.agent // Assuming CONFIG.agent is the project/agent ID
+  ),
   baseUrl: CONFIG.baseUrl,
   numberOfRetries: 10,
   versions: {


### PR DESCRIPTION
adding custom info header to cli requests made through cognigy client.

example header:

`'X-Cognigy-CLI-Info': 'cognigy-cli/1.6.4 project/6722201409dd9dee97022b13'`