### PR TITLE
Feature/98123 plybooks run not working properly

### DIFF
--- a/src/lib/playbooks.ts
+++ b/src/lib/playbooks.ts
@@ -1,6 +1,7 @@
 import CONFIG from '../utils/config';
 import CognigyClient from '../utils/cognigyClient';
 import * as fs from 'fs';
+import { checkTask } from '../utils/checks';
 
 interface Playbook {
   playbookId: string;
@@ -87,10 +88,11 @@ async function checkPlaybookRuns(
 
       // Check the status of all playbooks
       for (const scheduledPlaybookRun of scheduledPlaybookRuns) {
+        await checkTask(scheduledPlaybookRun.taskId);
         const task = await CognigyClient.readTask({
           taskId: scheduledPlaybookRun.taskId,
         });
-        const playbookRun = await waitForPlaybookRun({
+        const playbookRun = await CognigyClient.readPlaybookRun({
           playbookId: scheduledPlaybookRun.playbookId,
           playbookRunId: task.data.playbookRunId,
         });
@@ -131,51 +133,4 @@ async function checkPlaybookRuns(
       }
     }, 1000);
   });
-}
-
-/**
- * Waits for a playbook run to be available, retrying until timeout
- * @param playbookId The playbook ID
- * @param playbookRunId The run ID
- * @returns The playbook run object if found
- * @throws Error if not found within timeout
- */
-async function waitForPlaybookRun({
-  playbookId,
-  playbookRunId,
-}: {
-  playbookId: string;
-  playbookRunId: string;
-}): Promise<any> {
-  const timeoutMs: number = (CONFIG.playbookTimeoutSeconds || 10) * 1000;
-  const delayMs: number = 3000;
-  const startTime = Date.now();
-  let attempt = 0;
-
-  while (Date.now() - startTime < timeoutMs) {
-    attempt++;
-    try {
-      const playbookRun = await CognigyClient.readPlaybookRun({
-        playbookId,
-        playbookRunId,
-      });
-      console.log(`Playbook run found after ${attempt} attempt(s).`);
-      return playbookRun;
-    } catch (error: any) {
-      if (error.httpStatusCode === 404) {
-        console.log(
-          `Attempt ${attempt}: Playbook run not found (playbookId=${playbookId}, runId=${playbookRunId}). Retrying in ${delayMs}ms...`
-        );
-        await new Promise((res) => setTimeout(res, delayMs));
-      } else {
-        throw error; // Fail fast on non-404 errors
-      }
-    }
-  }
-
-  console.log(
-    `Timed out after ${timeoutMs / 1000}s: Playbook run ${playbookRunId} (playbookId=${playbookId}) was not found.\n` +
-      `Please check the status of the run in the Cognigy UI for more details.`
-  );
-  process.exit(2);
 }


### PR DESCRIPTION
Addressing [this issue](https://github.com/Cognigy/Cognigy-CLI/issues/145).

The current flow:

1) When a Playbook is scheduled, a task is returned. 
2) The task contains the PlaybookRunId corresponding to the Playbook run. 
3) We try to get the status of the the PlaybookRun. 

The problem here is that we aren't waiting for the task to be completed. As a result there were cases of errors being thrown about Playbook not being found because the run wasnt completed yet.