### PR TITLE
fix: filter out body data from GET/HEAD requests to prevent 403 errors

### DIFF
--- a/src/utils/RestAdapter.ts
+++ b/src/utils/RestAdapter.ts
@@ -133,15 +133,26 @@ export class RestAdapter implements IHttpAdapter {
     client: TRestAPIClient
   ): Promise<AxiosRequestConfig> {
     const baseUrl = request.baseUrl || this.config.baseUrl;
+    const method = request.method || 'GET';
 
     const axiosRequest: AxiosRequestConfig = {
-      data: request.data,
       headers: request.headers,
-      method: request.method || 'GET',
+      method,
       url: `${baseUrl}${request.url}`,
       // @ts-ignore
       validateStatus: null,
     };
+
+    if (method !== 'GET' && method !== 'HEAD') {
+      axiosRequest.data = request.data;
+    } else if (request.data) {
+      const stack = new Error().stack;
+      console.warn(
+        `Warning: RestAdapter: ${method} request to ${request.url} includes body data which will be ignored. ` +
+          `This may indicate an issue with the API client implementation. ` +
+          `Stack trace: ${stack}`
+      );
+    }
 
     return axiosRequest;
   }


### PR DESCRIPTION
## Summary
- Fixes #242 where some `cognigy execute` subcommands fail with 403 errors
- Filters out body data from GET and HEAD requests in RestAdapter
- Adds warning with stack trace to help identify incorrect API client calls

## Problem
Some REST API client methods incorrectly pass data as body in GET requests, which CloudFront rejects with 403 Forbidden errors. This affects commands like:
- `indexProjects`
- `indexApiKeysMe`
- `indexAuditEvents`
- `indexLoginAttemptsMe`
- `indexUsers`
- `indexUsersManagement`

## Solution
Modified `RestAdapter.convertRequest()` to:
1. Only include body data for methods that support it (not GET/HEAD)
2. Log a warning with stack trace when GET/HEAD requests attempt to include body data

This provides immediate protection against the 403 errors while helping developers identify and fix the root cause in the API client.

## Test plan
- [ ] Verify affected commands like `cognigy execute indexProjects` now work without 403 errors
- [ ] Confirm warning messages appear with helpful stack traces
- [ ] Ensure other HTTP methods (POST, PUT, PATCH) still include body data correctly

🤖 Generated with [Claude Code](https://claude.ai/code)