### PR TITLE
fix(project): correctly version cli upon release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -30,7 +30,7 @@ module.exports = {
     [
       '@semantic-release/git',
       {
-        assets: ['CHANGELOG.md'],
+        assets: ['CHANGELOG.md', 'package.json', 'package-lock.json'],
         message:
           // eslint-disable-next-line no-template-curly-in-string
           'chore(release): set `package.json` to ${nextRelease.version} [skip ci]',


### PR DESCRIPTION
Up until now we haven't added package.json+package-lock.json as files to be commited by semantic release.

In this commit I've added those files, as a result CLI will be correctly versioned upon release.

Important info: We install couple of dependencies in a [release step.](https://github.com/Cognigy/Cognigy-CLI/blob/6e89bd8a93638494a3c4c05ef856889c77d8b122/.github/workflows/release_2.yaml#L30) . As a result package.json + package-lock.json will have these newly added packages.