### PR TITLE
fix(deps): declare @langchain/classic dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@cognigy/rest-api-client": "2026.5.0",
         "@google-cloud/translate": "9.3.0",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
+        "@langchain/classic": "1.0.32",
         "@langchain/community": "1.1.28",
         "@langchain/core": "1.1.44",
         "axios": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@cognigy/rest-api-client": "2026.5.0",
     "@google-cloud/translate": "9.3.0",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
+    "@langchain/classic": "1.0.32",
     "@langchain/community": "1.1.28",
     "@langchain/core": "1.1.44",
     "axios": "1.16.0",


### PR DESCRIPTION
## Summary

First of all — thanks for maintaining this CLI, it's been really useful for managing agents from the command line.

While setting it up on a fresh machine I ran into a crash on the very first command. On a clean `npm install -g @cognigy/cognigy-cli`, `cognigy init` — and in fact every command — fails immediately with:

```
Error: Cannot find module '@langchain/classic/document_loaders/fs/text'
code: 'MODULE_NOT_FOUND'
```

This PR is the small change that fixed it for me: declaring `@langchain/classic` as a direct dependency.

## What I found

`src/lib/knowledgeAI/extractionProvider/lsExtractor.ts` imports directly from `@langchain/classic`:

```ts
import { TextLoader } from '@langchain/classic/document_loaders/fs/text';
import { ... } from '@langchain/classic/document_loaders/fs/json';
```

…but `@langchain/classic` isn't declared in the CLI's `dependencies` — it's only present transitively, via `@langchain/community` (which depends on `@langchain/classic: ^1.0.27`).

Because the CLI requires `classic` directly without declaring it, npm isn't obliged to hoist it to the CLI's top-level `node_modules`. On a clean end-user install it lands nested under community:

```
node_modules/@cognigy/cognigy-cli/node_modules/@langchain/community/node_modules/@langchain/classic
```

Node's module resolution, walking up from `lsExtractor.js`, only sees the CLI's own top-level `node_modules` — where `classic` is absent — so the bare `require('@langchain/classic/…')` fails. And since `program/index.js` registers every subcommand at load time, the crash takes down all commands, not just the KnowledgeAI ones.

I suspect this doesn't show up in development or CI because the lockfile-driven install (`npm ci`) happens to hoist `classic` to the top level, where it resolves fine.

## The change

One line — declare what's imported:

```diff
   "@istanbuljs/nyc-config-typescript": "1.0.2",
+  "@langchain/classic": "1.0.32",
   "@langchain/community": "1.1.28",
   "@langchain/core": "1.1.44",
```

I pinned `1.0.32` because it's the newest `@langchain/classic` whose `@langchain/core` peer range (`^1.0.0`) is satisfied by the `@langchain/core@1.1.44` already pinned here — so the diff stays minimal and nothing else moves. `@langchain/community` stays as-is (it still provides the pdf, docx, csv, epub, srt and web loaders).

## Alternatives considered

The essential part is declaring the package the code imports — but there's flexibility in how:

- **Bump `@langchain/core` to `^1.1.48` and take `@langchain/classic@1.0.34` (latest)** — works just as well, at the cost of also moving `core`. I went with the no-bump pin to keep the change minimal, but if you'd rather stay current (e.g. let Renovate manage both), I'm happy to rework the PR that way.
- **Updating other langchain packages alone** wouldn't be enough on its own — as long as the source imports `@langchain/classic` directly, it needs to be declared, or resolution keeps depending on incidental hoisting.

## How I verified

- Clean `npm install` — no peer-dependency warnings.
- `npm run build:production` — compiles clean.
- `npm pack`'d the result and did a fresh `npm install -g <tarball>` in a clean Node 22 container: `cognigy init` now reaches its first interactive prompt instead of crashing.
- The original crash reproduces on the published `@cognigy/cognigy-cli@2.2.8` on both Node 22 and Node 26.

Happy to adjust anything — and thanks again for the tool!
