### PR TITLE
ci: add NiCE SonarQube analysis (AB#142804)

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: SonarSource/sonarqube-scan-action@v7
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           SONAR_TOKEN: ${{ secrets.NICE_SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ vars.NICE_SONAR_HOST_URL }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,28 @@
+name: "CI | Cognigy-CLI Sonar"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  sonarqube:
+    name: "Cognigy-CLI - SonarQube Analysis"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: SonarSource/sonarqube-scan-action@v7
+        env:
+          SONAR_TOKEN: ${{ secrets.NICE_SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ vars.NICE_SONAR_HOST_URL }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.projectKey=com.nice.cognigy-alu-Cognigy-CLI
 sonar.projectName=cognigy-alu-Cognigy-CLI
 
 sonar.sources=.
+sonar.tests=.
 sonar.sourceEncoding=UTF-8
 
 sonar.exclusions=\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,24 @@
+sonar.projectKey=com.nice.cognigy-platform-Cognigy-CLI
+sonar.projectName=cognigy-platform-Cognigy-CLI
+
+sonar.sources=.
+sonar.sourceEncoding=UTF-8
+
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/dist/**,\
+  **/build/**,\
+  **/vendor/**,\
+  **/coverage/**,\
+  **/*.gen.go,\
+  **/*.gen.ts
+
+sonar.test.inclusions=\
+  **/*.test.ts,\
+  **/*.spec.ts,\
+  **/*_test.go,\
+  **/__tests__/**
+
+# Coverage (enable once CI emits reports - see https://cognigy.atlassian.net/wiki/spaces/Engineering/pages/2559967260 #3):
+# sonar.go.coverage.reportPaths=...
+# sonar.javascript.lcov.reportPaths=...

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=com.nice.cognigy-platform-Cognigy-CLI
-sonar.projectName=cognigy-platform-Cognigy-CLI
+sonar.projectKey=com.nice.cognigy-alu-Cognigy-CLI
+sonar.projectName=cognigy-alu-Cognigy-CLI
 
 sonar.sources=.
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Onboards this repo onto the NiCE corporate SonarQube instance (sonar.nice.com) per the org rollout tracked under [AB#142804](https://cognigy.visualstudio.com/4b97977f-75eb-49ca-b1da-4c64cfccb606/_workitems/edit/142804).
- Adds `.github/workflows/sonarqube.yml` using the org-level `NICE_SONAR_TOKEN` / `NICE_SONAR_HOST_URL`.
- Adds/updates `sonar-project.properties` with projectKey `com.nice.cognigy-alu-Cognigy-CLI` (team confirmed via GitHub Team/topic metadata and the Domain Ownership List).

## Changelog
- [x] [internal] Improved by adding NiCE SonarQube analysis to CI, so code quality, security findings and coverage for `Cognigy-CLI` are reported on every push and pull request.

Reference: [Using NiCE SonarQube](https://cognigy.atlassian.net/wiki/spaces/Engineering/pages/2559967260)
