### PR TITLE
CGY-37489 ci: report test coverage to SonarQube

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
       # always(): nyc still writes the lcov report when a spec fails, and
       # losing all coverage over one failing spec is how a project ends up back
       # at 0%. The test step above still fails the job, so nothing is hidden.
-      - uses: SonarSource/sonarqube-scan-action@v7
+      - uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7
         if: always()
         env:
           SONAR_TOKEN: ${{ secrets.NICE_SONAR_TOKEN }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -16,14 +16,39 @@ concurrency:
 jobs:
   sonarqube:
     name: "Cognigy-CLI - SonarQube Analysis"
+    # Fork PRs get no secrets. Guarding the job rather than only the scan step
+    # keeps a fork PR skipping cleanly instead of failing part-way.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 24.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # cp-config, exactly as health-check.yml does before its tests. Without
+      # it the CLI aborts with "Missing configuration in environment variables
+      # or config.json" before a single spec runs.
+      - name: Copy the default config
+        run: npm run cp-config
+
+      - name: Run tests with coverage
+        run: npm run coverage
+
+      # always(): nyc still writes the lcov report when a spec fails, and
+      # losing all coverage over one failing spec is how a project ends up back
+      # at 0%. The test step above still fails the job, so nothing is hidden.
       - uses: SonarSource/sonarqube-scan-action@v7
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: always()
         env:
           SONAR_TOKEN: ${{ secrets.NICE_SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ vars.NICE_SONAR_HOST_URL }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:debug": "rimraf ./build && tsc && npm run execution-permission",
     "build:production": "rimraf ./build && npm run tsc:production && npm run execution-permission",
     "execution-permission": "chmod +x ./build/cognigy.js",
-    "coverage": "rimraf ./coverage && nyc --all --extension=.ts --include='src/**/*.ts' --exclude='src/spec/**' --reporter=lcovonly --reporter=text-summary ts-mocha -p tsconfig.json --experimental-worker --recursive './src/spec/**/*.ts' --timeout 120000 --preserve-symlinks",
+    "coverage": "rimraf ./coverage && rimraf ./.nyc_output && nyc --all --extension=.ts --include='src/**/*.ts' --exclude='src/spec/**' --reporter=lcovonly --reporter=text-summary ts-mocha -p tsconfig.json --experimental-worker --recursive './src/spec/**/*.ts' --timeout 120000 --preserve-symlinks",
     "test": "rimraf ./coverage && nyc mocha --require chai-autoload-plugins --recursive ./build/spec --exit --timeout 120000 --color --check-leaks  && rimraf ./.nyc_output",
     "test:tsmocha": "ts-mocha -p tsconfig.json --experimental-worker --recursive './src/spec/**/*.ts' --timeout 120000 --preserve-symlinks",
     "install-from-npm": "npm --registry=https://registry.npmjs.com/ i",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:debug": "rimraf ./build && tsc && npm run execution-permission",
     "build:production": "rimraf ./build && npm run tsc:production && npm run execution-permission",
     "execution-permission": "chmod +x ./build/cognigy.js",
+    "coverage": "rimraf ./coverage && nyc --all --extension=.ts --include='src/**/*.ts' --exclude='src/spec/**' --reporter=lcovonly --reporter=text-summary ts-mocha -p tsconfig.json --experimental-worker --recursive './src/spec/**/*.ts' --timeout 120000 --preserve-symlinks",
     "test": "rimraf ./coverage && nyc mocha --require chai-autoload-plugins --recursive ./build/spec --exit --timeout 120000 --color --check-leaks  && rimraf ./.nyc_output",
     "test:tsmocha": "ts-mocha -p tsconfig.json --experimental-worker --recursive './src/spec/**/*.ts' --timeout 120000 --preserve-symlinks",
     "install-from-npm": "npm --registry=https://registry.npmjs.com/ i",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,6 +20,7 @@ sonar.test.inclusions=\
   **/*_test.go,\
   **/__tests__/**
 
-# Coverage (enable once CI emits reports - see https://cognigy.atlassian.net/wiki/spaces/Engineering/pages/2559967260 #3):
-# sonar.go.coverage.reportPaths=...
-# sonar.javascript.lcov.reportPaths=...
+# Coverage - emitted by the "Run tests with coverage" step in sonarqube.yml.
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+sonar.qualitygate.wait=true


### PR DESCRIPTION
Makes the SonarQube analysis report test coverage. The scan job only checked out the code and ran the scanner, so the specs never ran during analysis and the project sits at 0%. Part of CGY-37489, following the template landed in [llm-providers#208](https://github.com/Cognigy/llm-providers/pull/208).

## Why `npm test` could not just be reused

`.nycrc` sets `"all": true` while excluding `src`, so it measures `build/**`. `sonar.exclusions` drops `**/build/**`, so every file in that report comes back unresolved and Sonar records nothing — a green scan and 0% coverage, which is the single most common failure in this rollout.

The new `coverage` script overrides that scope on the command line and runs nyc over ts-mocha against `src` instead, which is what `sonar.sources` covers. `.nycrc` and `npm test` are untouched, so the existing build flow behaves exactly as before.

**No new dependency.** nyc is already here and works in this repo. Worth noting because it does *not* work in several siblings in this rollout: npm deduped `test-exclude@6`'s `minimatch@^3.0.4` onto a hoisted `minimatch@10` there, and even `nyc node -e ""` dies. Checked before relying on it.

## The step that is easy to miss

The job runs `npm run cp-config` before the tests, exactly as `health-check.yml` does. Without it the CLI aborts with:

```
Missing configuration in environment variables or config.json
```

before a single spec runs — and nyc then happily reports a coverage figure off an empty run, which looks like real, terrible coverage rather than no coverage. That is how I first measured 20.5% across 14 files; with `cp-config` it is 27.06% across 81.

## What else changed

- `sonarqube.yml` sets up Node 24.x, matching `health-check.yml`, installs dependencies, copies the config and runs `npm run coverage` before the scan.
- The job, not just the scan step, carries the same-repository condition, so a fork PR skips cleanly.
- The scan runs under `if: always()`, so one failing spec no longer discards the whole report.
- `sonar-project.properties` enables `sonar.javascript.lcov.reportPaths` and sets `sonar.qualitygate.wait=true`.

## How to test

1. `npm ci && npm run build && npm run cp-config && npm run coverage`. Expect 23 passing specs, 27.06% lines, and `coverage/lcov.info` with 81 entries at `src/...ts` paths.
2. Open the checks on this pull request and pick the SonarQube Analysis run. Confirm the log contains `Analysing [/home/runner/work/Cognigy-CLI/Cognigy-CLI/coverage/lcov.info]` and then `QUALITY GATE STATUS: PASSED`.
3. After merge, open the project on sonar.nice.com and confirm the coverage value on `main` is above 0.

Dependencies install with `npm ci --ignore-scripts`. A plain `npm ci` is reported by SonarQube as a security hotspot and the gate requires 100% of new-code hotspots reviewed, so it fails the job on its own.